### PR TITLE
Bring `AbstractAdminUser` in line with Django 1.8

### DIFF
--- a/polymorphic_auth/migrations/0002_auto_20160725_2124.py
+++ b/polymorphic_auth/migrations/0002_auto_20160725_2124.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('polymorphic_auth', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='user',
+            name='groups',
+            field=models.ManyToManyField(related_query_name='user', related_name='user_set', to='auth.Group', blank=True, help_text='The groups this user belongs to. A user will get all permissions granted to each of their groups.', verbose_name='groups'),
+        ),
+        migrations.AlterField(
+            model_name='user',
+            name='last_login',
+            field=models.DateTimeField(null=True, verbose_name='last login', blank=True),
+        ),
+    ]


### PR DESCRIPTION
Make our user model explicitly match the default fields used in Django
1.8+ and make backwards-compatible with Django 1.7 projects.
- add 0002 DB migration to make the `User` DB line up with upstream
  changes to `AbstractBaseUser` in Django 1.8
- monkey-patch `AbstractAdminUser` when used in Django 1.7 projects to
  bring `AbstractAdminUser` into line with field changes in Django 1.8
  so the new 0002 migration is definitive and final
- remove the work-around to always set a value in the `last_login`
  previously required for Django 1.7, since our user models no longer
  require a value for this field.

See https://docs.djangoproject.com/en/1.9/releases/1.8/#s-abstractuser-last-login-allows-null-values
