### PR TITLE
Make email user email case insensitive

### DIFF
--- a/polymorphic_auth/admin.py
+++ b/polymorphic_auth/admin.py
@@ -63,12 +63,11 @@ def _check_for_username_case_insensitive_clash(form):
     user = form.instance
     if user and user.IS_USERNAME_CASE_INSENSITIVE:
         username = form.cleaned_data[user.USERNAME_FIELD]
-        filters = {
+        matching_users = type(user).objects.filter(**{
             '%s__iexact' % user.USERNAME_FIELD: username,
-        }
+        })
         if user.pk:
-            filters['pk__neq'] = user.pk
-        matching_users = type(user).objects.filter(**filters)
+            matching_users = matching_users.exclude(pk=user.pk)
         if matching_users:
             raise forms.ValidationError(
                 u"A user with that %s already exists." % user.USERNAME_FIELD)

--- a/polymorphic_auth/models.py
+++ b/polymorphic_auth/models.py
@@ -196,6 +196,18 @@ class UserManager(PolymorphicManager, BaseUserManager):
         extra_fields.update(is_staff=True, is_superuser=True)
         return self._create_user(password, **extra_fields)
 
+    def get_by_natural_key(self, username):
+        """
+        Override default user lookup behaviour to match username (really email)
+        field with case INsensitivity for email-address based users.
+        """
+        if getattr(self.model, 'IS_USERNAME_CASE_INSENSITIVE', False):
+            return self.get(**{
+                '%s__iexact' % self.model.USERNAME_FIELD: username.lower()
+            })
+        else:
+            return super(UserManager, self).get_by_natural_key(username)
+
 
 # MODELS ######################################################################
 

--- a/polymorphic_auth/models.py
+++ b/polymorphic_auth/models.py
@@ -293,14 +293,16 @@ class AbstractAdminUser(
         # Hack to force check for potential duplicate users before save, in
         # case more user-friendly validation sanity checks have not been
         # implemented or have been bypassed.
-        if not self.pk and self.IS_USERNAME_CASE_INSENSITIVE:
+        if self.IS_USERNAME_CASE_INSENSITIVE:
             matching_users = type(self).objects.filter(**{
                 '%s__iexact' % self.USERNAME_FIELD: self.username
             })
+            if self.pk:
+                matching_users = matching_users.exclude(pk=self.pk)
             if matching_users:
                 raise Exception(
-                    u"Username field '%s' matches existing user(s): %s"
-                    % (self.USERNAME_FIELD, matching_users))
+                    u"Identifier field %s='%s' matches existing users: %s"
+                    % (self.USERNAME_FIELD, self.username, matching_users))
 
         super(AbstractAdminUser, self).save(*args, **kwargs)
 

--- a/polymorphic_auth/usertypes/email/models.py
+++ b/polymorphic_auth/usertypes/email/models.py
@@ -10,6 +10,8 @@ class AbstractEmailUser(User, EmailFieldMixin):
     USERNAME_FIELD = 'email'
     REQUIRED_FIELDS = ['first_name', 'last_name']
 
+    IS_USERNAME_CASE_INSENSITIVE = True
+
     class Meta:
         abstract = True
         verbose_name = _('user with email login')

--- a/polymorphic_auth/usertypes/email/tests.py
+++ b/polymorphic_auth/usertypes/email/tests.py
@@ -1,0 +1,131 @@
+from django_webtest import WebTest
+
+from django.core.urlresolvers import reverse
+
+from .models import EmailUser
+
+
+class TestEmailUser(WebTest):
+
+    def setUp(self):
+        self.superuser = EmailUser.objects.create(
+            email='superuser@test.com',
+            is_staff=True,
+            is_active=True,
+            is_superuser=True,
+        )
+        self.superuser.set_password('abc123')
+        self.superuser.save()
+
+    def test_cannot_create_user_with_same_email(self):
+        # Cannot create a user with an exactly matching email
+        try:
+            EmailUser.objects.create(email='superuser@test.com')
+        except Exception, ex:
+            self.assertTrue('matches existing users' in ex.message)
+
+        # Cannot create a user with an equivalent email when case is ignored
+        try:
+            EmailUser.objects.create(email='Superuser@test.com')
+        except Exception, ex:
+            self.assertTrue('matches existing users' in ex.message)
+
+    def test_cannot_modify_user_to_have_same_email(self):
+        user = EmailUser.objects.create(email='another@test.com')
+        # Cannot create a user with an exactly matching email
+        user.email = 'superuser@test.com'
+        try:
+            user.save()
+        except Exception, ex:
+            self.assertTrue('matches existing users' in ex.message)
+
+        # Cannot create a user with an equivalent email when case is ignored
+        user.email = 'Superuser@test.com'
+        try:
+            user.save()
+        except Exception, ex:
+            self.assertTrue('matches existing users' in ex.message)
+
+    def test_can_modify_existing_user(self):
+        self.superuser.first_name = 'Sir'
+        self.superuser.last_name = 'Test'
+        self.superuser.save()
+        reloaded_superuser = EmailUser.objects.get(pk=self.superuser.pk)
+        self.assertEqual('Sir', reloaded_superuser.first_name)
+        self.assertEqual('Test', reloaded_superuser.last_name)
+
+    def test_cannot_create_user_with_same_email_in_admin(self):
+        response = self.app.get(
+            reverse('admin:polymorphic_auth_user_add'),
+            user=self.superuser
+        ).maybe_follow()
+        form = response.form
+
+        # Cannot create a user with an exactly matching email
+        form['email'] = 'superuser@test.com'
+        form['password1'] = 'testpassword'
+        form['password2'] = 'testpassword'
+        response = form.submit(user=self.superuser)
+        self.assertTrue(
+            # Default form field error on 'email' field
+            'A user with that email address already exists' in response.text)
+        self.assertTrue(
+            # General error on "username" identifier field
+            'A user with that email already exists' in response.text)
+
+        # Cannot create a user with an equivalent email when case is ignored
+        form['email'] = 'Superuser@test.com'
+        form['password1'] = 'testpassword'
+        form['password2'] = 'testpassword'
+        response = form.submit(user=self.superuser)
+        self.assertFalse(
+            # Default form field error on 'email' field NOT PRESENT
+            'A user with that email address already exists' in response.text)
+        self.assertTrue(
+            # General error on "username" identifier field
+            'A user with that email already exists' in response.text)
+
+    def test_cannot_modify_user_to_have_same_email_in_admin(self):
+        user = EmailUser.objects.create(email='another@test.com')
+
+        response = self.app.get(
+            reverse('admin:polymorphic_auth_user_change',
+                    args=(user.pk,)),
+            user=self.superuser
+        ).maybe_follow()
+        form = response.form
+
+        # Cannot modify a user to have an exactly matching email
+        form['email'] = 'superuser@test.com'
+        response = form.submit(user=self.superuser)
+        self.assertTrue(
+            # Default form field error on 'email' field
+            'A user with that email address already exists' in response.text)
+        self.assertTrue(
+            # General error on "username" identifier field
+            'A user with that email already exists' in response.text)
+
+        # Cannot modify a user to have an equivalent email when case is ignored
+        form['email'] = 'Superuser@test.com'
+        response = form.submit(user=self.superuser)
+        self.assertFalse(
+            # Default form field error on 'email' field NOT PRESENT
+            'A user with that email address already exists' in response.text)
+        self.assertTrue(
+            # General error on "username" identifier field
+            'A user with that email already exists' in response.text)
+
+    def test_can_modify_existing_user_in_admin(self):
+        self.superuser.first_name = 'Sir Test'
+        response = self.app.get(
+            reverse('admin:polymorphic_auth_user_change',
+                    args=(self.superuser.pk,)),
+            user=self.superuser
+        ).maybe_follow()
+        form = response.form
+        form['first_name'] = 'Sir'
+        form['last_name'] = 'Test'
+        response = form.submit()
+        reloaded_superuser = EmailUser.objects.get(pk=self.superuser.pk)
+        self.assertEqual('Sir', reloaded_superuser.first_name)
+        self.assertEqual('Test', reloaded_superuser.last_name)


### PR DESCRIPTION
Make the `EmailUser` user type in particular, and specially-flagged user types in general, work properly with case-insensitive user identifiers (`username` field behind the scenes) such that:

* users cannot be created with duplicate identifiers differing only by case
* users cannot be modified to have a duplicate identifier differing only by case
* admin forms show validation errors for both of the cases above.